### PR TITLE
Handle connection errors

### DIFF
--- a/js-client/src/App.js
+++ b/js-client/src/App.js
@@ -20,7 +20,15 @@ function App() {
     stream.on('data', function(response){
         setTemp(response.getValue())
     });
-  };
+    stream.on('status', function(status) {
+        // see: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+        if (status.code > 0) {
+            console.log("restarting")
+            stream.cancel()
+            setTimeout(_ => getTemp(), 1000)
+        }
+    });
+  }
 
   const getHumidity = () => {
     var sensorRequest = new SensorRequest()
@@ -29,6 +37,12 @@ function App() {
     stream.on('data',function(response){
       setHumidity(response.getValue())
     })
+    stream.on('status', function(status) {
+        if (status.code > 0) {
+            stream.cancel()
+            setTimeout(_ => getHumidity(), 1000)
+        }
+    });
   }
 
   const detectTempAlert = () => {

--- a/server/server.go
+++ b/server/server.go
@@ -18,13 +18,14 @@ type server struct {
 func (s *server) TempSensor(req *sensorpb.SensorRequest,
 	stream sensorpb.Sensor_TempSensorServer) error {
 	for {
-		time.Sleep(time.Second * 5)
-
 		temp := s.Sensor.GetTempSensor()
 		err := stream.Send(&sensorpb.SensorResponse{Value: temp})
 		if err != nil {
 			log.Println("Error sending metric message ", err)
+			return nil
 		}
+
+		time.Sleep(time.Second * 5)
 	}
 	return nil
 }
@@ -33,14 +34,15 @@ func (s *server) HumiditySensor(req *sensorpb.SensorRequest,
 	stream sensorpb.Sensor_HumiditySensorServer) error {
 
 	for {
-		time.Sleep(time.Second * 2)
-
 		humd := s.Sensor.GetHumiditySensor()
 
 		err := stream.Send(&sensorpb.SensorResponse{Value: humd})
 		if err != nil {
 			log.Println("Error sending metric message ", err)
+			return nil
 		}
+
+		time.Sleep(time.Second * 2)
 	}
 	return nil
 }


### PR DESCRIPTION
# js-client: reconnect on error

This changes makes the client automatically reconnect when
a error occurs.

# server: gracefully stop client handler on error

This change improves the server by stopping the client handler
on error, instead of printing error continously.

This change also moves the delay after sending the response so
that it is snappier.
